### PR TITLE
Silence the "already initialized constant Zlib::RLE" (on ruby-2.0.0-p0)

### DIFF
--- a/lib/archive/support/zlib.rb
+++ b/lib/archive/support/zlib.rb
@@ -11,11 +11,11 @@ module Zlib # :nodoc:
 
   # A deflate strategy which limits match distances to 1, also known as
   # run-length encoding.
-  RLE = 3
+  RLE = 3 unless defined?(Zlib::RLE)
 
   # A deflate strategy which does not use dynamic Huffman codes, allowing for a
   # simpler decoder to be used to inflate.
-  FIXED = 4
+  FIXED = 4 unless defined?(Zlib::FIXED)
 
   # Zlib::ZWriter is a writable, IO-like object (includes IO::Like) which wraps
   # other writable, IO-like objects in order to facilitate writing data to those


### PR DESCRIPTION
Hi, hereby the pull request. Please act as you see fit and please note that I'm not really aware about what these constants do or mean. I just know they are being redefined with the same values on ruby-2.0.0-p0.
