### PR TITLE
⚠️ Ruby warnings

### DIFF
--- a/lib/archive/zip/entry.rb
+++ b/lib/archive/zip/entry.rb
@@ -932,7 +932,7 @@ module Archive; class Zip; module Entry
     # Sets the link target for this entry.  As a side effect, the raw_data
     # attribute is set to +nil+.
     def link_target=(link_target)
-      raw_data = nil
+      self.raw_data = nil
       @link_target = link_target
     end
 

--- a/lib/archive/zip/extra_field/unix.rb
+++ b/lib/archive/zip/extra_field/unix.rb
@@ -113,15 +113,6 @@ module Archive; class Zip; module ExtraField
     # This method signature is part of the interface contract expected by
     # Archive::Zip::Entry for extra field objects.
     #
-    # Returns a String suitable to writing to a central file record in a ZIP
-    # archive file which contains the data for this object.
-    def dump_central
-      ''
-    end
-
-    # This method signature is part of the interface contract expected by
-    # Archive::Zip::Entry for extra field objects.
-    #
     # Returns a String suitable to writing to a local file record in a ZIP
     # archive file which contains the data for this object.
     def dump_local
@@ -134,7 +125,13 @@ module Archive; class Zip; module ExtraField
         @gid
       ].pack('vvVVvv') + @data
     end
-    alias :dump_local :dump_central
+
+    # This method signature is part of the interface contract expected by
+    # Archive::Zip::Entry for extra field objects.
+    #
+    # Returns a String suitable to writing to a central file record in a ZIP
+    # archive file which contains the data for this object.
+    alias :dump_central :dump_local
 
     protected
 


### PR DESCRIPTION
This PR removes Ruby warnings.
I'm not totally sure about removing the whole `Archive::Zip::ExtraField::Unix
#dump_local` logic, but in fact the code is currently not at all in use because the method is redefined right afterwards.