### PR TITLE
Update for filtering by file type

### DIFF
--- a/lib/archive/zip.rb
+++ b/lib/archive/zip.rb
@@ -368,6 +368,7 @@ module Archive # :nodoc:
       options[:directories]  = true  unless options.has_key?(:directories)
       options[:symlinks]     = false unless options.has_key?(:symlinks)
       options[:flatten]      = false unless options.has_key?(:flatten)
+	  options[:file_types]   = [] unless options.has_key?(:file_types)
 
       # Flattening the directory structure implies that directories are skipped
       # and that the path prefix should be ignored.
@@ -375,7 +376,13 @@ module Archive # :nodoc:
         options[:path_prefix] = ''
         options[:directories] = false
       end
-
+	  
+	  # Filter out unwanted filetypes. Ignore case and allow directories
+      if !options[:file_types].empty? then
+        options[:file_types].each{|file_type| file_type.downcase!}
+        paths.reject!{|path| !options[:file_types].include?(File.extname(path.downcase)) && !File.directory?(path)}
+      end
+	  
       # Clean up the path prefix.
       options[:path_prefix] = Entry.expand_path(options[:path_prefix].to_s)
 


### PR DESCRIPTION
I might have overlooked it, but I didn't see an option for filtering by filetype.

This update creates an option ':file_types' that accepts an array of
file extensions. It then rejects any paths that don't contain an
approved extension. Directories are unaffected.

I tested it on a handful of files and it worked as expected. All it does is remove files from the list of paths based on extension.