### PR TITLE
Suppress warning messages

### DIFF
--- a/lib/archive/zip.rb
+++ b/lib/archive/zip.rb
@@ -151,6 +151,7 @@ module Archive # :nodoc:
       @entries = []
       @comment = ''
       @closed = false
+      @parse_complete = false
     end
 
     # A comment string for the ZIP archive.

--- a/lib/archive/zip/entry.rb
+++ b/lib/archive/zip/entry.rb
@@ -481,8 +481,8 @@ module Archive; class Zip
       self.expected_data_descriptor = nil
       self.compression_codec = Zip::Codec::Store.new
       self.encryption_codec = Zip::Codec::NullEncryption.new
-      self.password = nil
       @raw_data = raw_data
+      self.password = nil
       @extra_fields = []
     end
 


### PR DESCRIPTION
I found that warning messages appears when calling some methods of `Archive::Zip`: 

```
> bundle exec irb -w
rb(main):001:0> require 'archive/zip'
=> true
irb(main):002:0> Archive::Zip.archive('example1.zip', 'lib/.')
/Users/tatsuya.b.sato/Projects/private/archive-zip/lib/archive/zip.rb:208: warning: instance variable @parse_complete not initialized
/Users/tatsuya.b.sato/Projects/private/archive-zip/lib/archive/zip/entry.rb:1040: warning: instance variable @raw_data not initialized
/Users/tatsuya.b.sato/Projects/private/archive-zip/lib/archive/zip/entry.rb:1040: warning: instance variable @raw_data not initialized
```

This PR provides small changes to suppress the warning messages.